### PR TITLE
Transient structures

### DIFF
--- a/spec/immutable/map/transient_spec.cr
+++ b/spec/immutable/map/transient_spec.cr
@@ -1,0 +1,36 @@
+require "../../spec_helper"
+
+describe Immutable::Map::Transient do
+  describe "#set" do
+    it "sets a key-value pair" do
+      t = Immutable::Map::Transient(Symbol, Int32).new
+      t.set(:foo, 1)[:foo].should eq(1)
+    end
+  end
+
+  describe "#delete" do
+    it "deletes a key-value pair" do
+      t = Immutable::Map::Transient(Symbol, Int32).new({ foo: 1, bar: 2 })
+      t.delete(:foo).fetch(:foo, nil).should eq(nil)
+    end
+  end
+
+  describe "#merge" do
+    it "merges key-value pairs" do
+      t = Immutable::Map::Transient(Symbol, Int32).new({ foo: 1, bar: 2 })
+      t.merge({ baz: 3 })[:baz].should eq(3)
+    end
+  end
+
+  describe "#persist!" do
+    it "returns a persistent immutable vector unaffected by further changes" do
+      tr = Immutable::Map::Transient(Symbol, Int32).new({ foo: 1, bar: 2 })
+      m = tr.persist!
+      m.should be_a(Immutable::Map(Symbol, Int32))
+      m.should_not be_a(Immutable::Map::Transient(Symbol, Int32))
+      tr = tr.delete(:foo).set(:baz, 3).merge({ qux: 4, quux: 5 })
+      tr.to_h.should eq({ bar: 2, baz: 3, qux: 4, quux: 5 })
+      m.to_h.should eq({ foo: 1, bar: 2 })
+    end
+  end
+end

--- a/spec/immutable/map/trie_spec.cr
+++ b/spec/immutable/map/trie_spec.cr
@@ -78,4 +78,32 @@ describe Immutable::Map::Trie do
       t.each.to_a.should eq(t.to_a)
     end
   end
+
+  describe "in-place modifications" do
+    describe "when modified by the owner" do
+      it "#set! and #delete! modify in place" do
+        t = Immutable::Map::Trie(Symbol, Int32).empty(42_u64)
+        t.set!(:foo, 0, 42_u64)
+        t.set!(:bar, 1, 42_u64)
+        t.get(:foo).should eq(0)
+        t.get(:bar).should eq(1)
+        t.delete!(:foo, 42_u64)
+        t.has_key?(:foo).should eq(false)
+      end
+    end
+
+    describe "when modified by an object that is not the owner" do
+      it "#set! and #delete! return a modified copy" do
+        t = Immutable::Map::Trie(Symbol, Int32).empty(42_u64)
+        x = t.set!(:foo, 0, 0_u64)
+        t.has_key?(:foo).should eq(false)
+        x.get(:foo).should eq(0)
+        t.set!(:foo, 0, 42_u64)
+        x = t.delete!(:foo, 0_u64)
+        t.get(:foo).should eq(0)
+        t.has_key?(:foo).should eq(true)
+        x.has_key?(:foo).should eq(false)
+      end
+    end
+  end
 end

--- a/spec/immutable/map_spec.cr
+++ b/spec/immutable/map_spec.cr
@@ -222,5 +222,18 @@ describe Immutable do
         m1.hash.should eq(m2.hash)
       end
     end
+
+    describe "transient" do
+      it "yields a transient map and converts back to an immutable one" do
+        map = empty_map.transient do |m|
+          m.should be_a(Immutable::Map::Transient(String, Int32))
+          100.times { |i| m = m.set(i.to_s, i) }
+        end
+        map.should be_a(Immutable::Map(String, Int32))
+        map.should_not be_a(Immutable::Map::Transient(String, Int32))
+        map.size.should eq(100)
+        empty_map.size.should eq(0)
+      end
+    end
   end
 end

--- a/spec/immutable/vector/transient_spec.cr
+++ b/spec/immutable/vector/transient_spec.cr
@@ -1,0 +1,43 @@
+require "../../spec_helper"
+
+describe Immutable::Vector::Transient do
+  empty_transient = Immutable::Vector::Transient(Int32).new
+
+  describe "#push" do
+    it "pushes elements into the transient" do
+      tr = Immutable::Vector::Transient(Int32).new
+      100.times { |i| tr = tr.push(i) }
+      tr.size.should eq(100)
+    end
+  end
+
+  describe "#set" do
+    it "sets elements of the transient" do
+      tr = Immutable::Vector::Transient.new([1, 2, 3])
+      tr.set(1, 0)[1].should eq(0)
+    end
+  end
+
+  describe "#pop" do
+    it "sets elements of the transient" do
+      tr = Immutable::Vector::Transient.new([1, 2, 3])
+      elem, t = tr.pop
+      elem.should eq(3)
+      t.size.should eq(2)
+    end
+  end
+
+  describe "#persist!" do
+    it "returns a persistent immutable vector" do
+      tr = Immutable::Vector::Transient(Int32).new
+      100.times { |i| tr = tr.push(i) }
+      v = tr.persist!
+      tr.pop
+      tr.pop
+      tr.push(100).set(50, 0)
+      tr.size.should eq(99)
+      v.size.should eq(100)
+      v[50].should eq(50)
+    end
+  end
+end

--- a/spec/immutable/vector/transient_spec.cr
+++ b/spec/immutable/vector/transient_spec.cr
@@ -28,16 +28,19 @@ describe Immutable::Vector::Transient do
   end
 
   describe "#persist!" do
-    it "returns a persistent immutable vector" do
+    it "returns a persistent immutable vector unaffected by further changes" do
       tr = Immutable::Vector::Transient(Int32).new
       100.times { |i| tr = tr.push(i) }
       v = tr.persist!
-      tr.pop
-      tr.pop
-      tr.push(100).set(50, 0)
+      v.should be_a(Immutable::Vector(Int32))
+      _, tr = tr.pop
+      _, tr = tr.pop
+      tr = tr.push(100).set(50, 0).set(98, 0)
       tr.size.should eq(99)
+      tr.last.should eq(0)
       v.size.should eq(100)
       v[50].should eq(50)
+      v.last.should eq(99)
     end
   end
 end

--- a/spec/immutable/vector/trie_spec.cr
+++ b/spec/immutable/vector/trie_spec.cr
@@ -273,6 +273,18 @@ describe Immutable::Vector::Trie do
         t.size.should eq(10)
         t2.size.should eq(100)
       end
+
+      it "#push_leaf! and #pop_leaf! return a modified copy" do
+        block_size = Immutable::Vector::Trie::BLOCK_SIZE
+        t = Immutable::Vector::Trie.new([] of Int32, 42_u64)
+        3.times do |i|
+          t = t.push_leaf!((0...block_size).to_a, 42_u64)
+        end
+        x = t.push_leaf!((0...block_size).to_a, 1_u64)
+        x.should_not eq(t)
+        x = t.pop_leaf!(1_u64)
+        x.should_not eq(t)
+      end
     end
   end
 end

--- a/spec/immutable/vector/trie_spec.cr
+++ b/spec/immutable/vector/trie_spec.cr
@@ -209,7 +209,9 @@ describe Immutable::Vector::Trie do
         not_in_place.should eq(1)
         # update!
         t.update!(50, 0, 42_u64)
+        t.update!(99, 0, 42_u64)
         t.get(50).should eq(0)
+        t.get(99).should eq(0)
         # pop!
         not_in_place = 0
         90.times do |i|
@@ -260,7 +262,9 @@ describe Immutable::Vector::Trie do
         t2.size.should eq(0)
         # update!
         t.update!(50, 0, 2_u64)
+        t.update!(99, 0, 2_u64)
         t.get(50).should eq(50)
+        t.get(99).should eq(99)
         # pop!
         not_in_place = 0
         t2 = t

--- a/spec/immutable/vector/trie_spec.cr
+++ b/spec/immutable/vector/trie_spec.cr
@@ -194,4 +194,21 @@ describe Immutable::Vector::Trie do
       t.get(999).should eq(999)
     end
   end
+
+  describe "in-place modifications" do
+    describe "#update!" do
+      it "modifies in place if from matches owner" do
+        t = Immutable::Vector::Trie.new([1, 2, 3], 42_u64)
+        t.update!(1, 0, 42_u64)
+        t.get(1).should eq(0)
+      end
+
+      it "returns a modified copy if from does not matches owner" do
+        t = Immutable::Vector::Trie.new([1, 2, 3], 123_u64)
+        t2 = t.update!(1, 0, 42_u64)
+        t2.get(1).should eq(0)
+        t.get(1).should eq(2)
+      end
+    end
+  end
 end

--- a/spec/immutable/vector/trie_spec.cr
+++ b/spec/immutable/vector/trie_spec.cr
@@ -246,7 +246,7 @@ describe Immutable::Vector::Trie do
     end
 
     describe "when modified by an object who's not the owner" do
-      it "returns a modified copy" do
+      it "#push!, #update and #pop! return a modified copy" do
         t = Immutable::Vector::Trie.new([] of Int32, 42_u64)
         t2 = t
         not_in_place = 0

--- a/spec/immutable/vector/trie_spec.cr
+++ b/spec/immutable/vector/trie_spec.cr
@@ -197,7 +197,7 @@ describe Immutable::Vector::Trie do
 
   describe "in-place modifications" do
     describe "when modified by the owner" do
-      it "modify in place (most of the times)" do
+      it "#push! #update! and #pop! modify in place" do
         # push!
         t = Immutable::Vector::Trie.new([] of Int32, 42_u64)
         not_in_place = 0
@@ -219,6 +219,29 @@ describe Immutable::Vector::Trie do
         end
         not_in_place.should eq(1)
         t.size.should eq(10)
+      end
+
+      it "#push_leaf! and #pop_leaf! modify in place" do
+        block_size = Immutable::Vector::Trie::BLOCK_SIZE
+        t = Immutable::Vector::Trie.new([] of Int32, 42_u64)
+        not_in_place = 0
+        # push_leaf!
+        (block_size.to_i + 1).times do |i|
+          x = t.push_leaf!((i*block_size...i * block_size + block_size).to_a, 42_u64)
+          not_in_place += 1 unless x == t
+          t = x
+        end
+        not_in_place.should eq(3)
+        t.size.should eq(block_size * (block_size + 1))
+        # pop_leaf!
+        not_in_place = 0
+        block_size.times do |i|
+          x = t.pop_leaf!(42_u64)
+          not_in_place += 1 unless x == t
+          t = x
+        end
+        not_in_place.should eq(2)
+        t.size.should eq(block_size)
       end
     end
 

--- a/spec/immutable/vector_spec.cr
+++ b/spec/immutable/vector_spec.cr
@@ -346,11 +346,11 @@ describe Immutable do
       it "yields a transient vector and converts back to an immutable one" do
         vec = empty_vector.transient do |v|
           v.should be_a(Immutable::Vector::Transient(Int32))
-          1000.times { |i| v = v.push(i) }
+          100.times { |i| v = v.push(i) }
         end
         vec.should be_a(Immutable::Vector(Int32))
         vec.should_not be_a(Immutable::Vector::Transient(Int32))
-        vec.size.should eq(1000)
+        vec.size.should eq(100)
         empty_vector.size.should eq(0)
       end
     end

--- a/spec/immutable/vector_spec.cr
+++ b/spec/immutable/vector_spec.cr
@@ -341,5 +341,18 @@ describe Immutable do
         vector.to_json.should eq(vector.to_a.to_json)
       end
     end
+
+    describe "transient" do
+      it "yields a transient vector and converts back to an immutable one" do
+        vec = empty_vector.transient do |v|
+          v.should be_a(Immutable::Vector::Transient(Int32))
+          1000.times { |i| v = v.push(i) }
+        end
+        vec.should be_a(Immutable::Vector(Int32))
+        vec.should_not be_a(Immutable::Vector::Transient(Int32))
+        vec.size.should eq(1000)
+        empty_vector.size.should eq(0)
+      end
+    end
   end
 end

--- a/src/immutable/map.cr
+++ b/src/immutable/map.cr
@@ -21,7 +21,7 @@
 require "./map/trie"
 
 module Immutable
-  struct Map(K, V)
+  class Map(K, V)
     @trie  : Trie(K, V)
     @block : (K -> V)?
 
@@ -306,6 +306,85 @@ module Immutable
       reduce(size * 43) do |memo, keyval|
         key, value = keyval.first, keyval.last
         43 * memo + (key.hash ^ value.hash)
+      end
+    end
+
+    def ==(other : Map(L, W))
+      # TODO: optimize
+      return true if @trie.same?(other.trie)
+      return false unless size == other.size
+      all? do |kv|
+        other.trie.has_key?(kv[0]) && other.trie.get(kv[0]) == kv[1]
+      end
+    end
+
+    # :nodoc:
+    def ==(other)
+      false
+    end
+
+    protected def trie : Trie(K, V)
+      @trie
+    end
+
+    class Transient(K, V) < Map(K, V)
+      @trie  : Trie(K, V)
+      @block : (K -> V)?
+
+      def initialize(hash = {} of K => V : Hash(K, V))
+        @trie  = hash.reduce(Trie(K, V).empty(object_id)) do |h, k, v|
+          h.set!(k, v, object_id)
+        end
+        @block = nil
+      end
+
+      def initialize(hash = {} of K => V : Hash(K, V), &block : K -> V)
+        @trie  = hash.reduce(Trie(K, V).empty(object_id)) do |h, k, v|
+          h.set!(k, v, object_id)
+        end
+        @block = block
+      end
+
+      # :nodoc:
+      def initialize(@trie : Trie(K, V), @block = nil : (K -> V)?)
+      end
+
+      def self.new(e : Enumerable(Enumerable(U)))
+        e.reduce(Transient(typeof(e.first[0]), typeof(e.first[1])).new) do |m, kv|
+          m.set!(kv[0], kv[1], object_id)
+        end
+      end
+
+      def set(key : K, value : V)
+        @trie = @trie.set!(key, value, object_id)
+        self
+      end
+
+      def delete(key : K)
+        @trie = @trie.delete!(key, object_id)
+        self
+      end
+
+      def merge(hash : Hash(K, V))
+        @trie = hash.reduce(@trie) do |trie, key, value|
+          trie.set!(key, value, object_id)
+        end
+        self
+      end
+
+      def merge(map : Map(K, V))
+        @trie = map.reduce(@trie) do |trie, keyval|
+          trie.set!(keyval[0], keyval[1], object_id)
+        end
+        self
+      end
+
+      def merge(hash : Hash(L, W))
+        Transient(K | L, V | W).new.merge(self).merge(hash)
+      end
+
+      def merge(map : Map(L, W))
+        Transient(K | L, V | W).new.merge(self).merge(map)
       end
     end
   end

--- a/src/immutable/map.cr
+++ b/src/immutable/map.cr
@@ -71,6 +71,22 @@ module Immutable
       t.persist!
     end
 
+    # Executes the given block passing a transient version of the map, then
+    # converts the transient map back to an immutable one and returns it.
+    #
+    # This is useful to perform several updates on a map in an efficient way: as
+    # the transient map supports the same API of map, but performs updates in
+    # place, avoiding unnecessary object allocations.
+    #
+    # ```
+    # map = Immutable::Map(Int32, Int32).new
+    # m2 = map.transient do |m|
+    #   100.times { |i| m = m.set(i, i * 2) }
+    # end
+    # m2.size # => 100
+    # ```
+    #
+    # Note that, as the transient is mutable, it is not thread-safe.
     def transient
       t = Transient.new(@trie, @block)
       yield t

--- a/src/immutable/map.cr
+++ b/src/immutable/map.cr
@@ -33,7 +33,10 @@ module Immutable
     # m = Immutable::Map.new({ foo: 123, bar: 321 }) # Map {foo: 123, bar: 321}
     # ```
     def initialize(hash = {} of K => V : Hash(K, V))
-      @trie  = hash.reduce(Trie(K, V).empty) { |h, k, v| h.set(k, v) }
+      @trie  = hash.reduce(Trie(K, V).empty(object_id)) do |trie, k, v|
+        trie.set!(k, v, object_id)
+      end
+      trie.clear_owner!
       @block = nil
     end
 
@@ -310,11 +313,11 @@ module Immutable
     end
 
     def ==(other : Map(L, W))
-      # TODO: optimize
       return true if @trie.same?(other.trie)
       return false unless size == other.size
       all? do |kv|
-        other.trie.has_key?(kv[0]) && other.trie.get(kv[0]) == kv[1]
+        entry = other.trie.find_entry(kv[0])
+        entry && entry.value == kv[1]
       end
     end
 

--- a/src/immutable/vector.cr
+++ b/src/immutable/vector.cr
@@ -66,6 +66,22 @@ module Immutable
       @tail = elems[leaves..-1]
     end
 
+    # Executes the given block passing a transient version of the vector, then
+    # converts the transient vector back to an immutable one and returns it.
+    #
+    # This is useful to perform several updates on a vector in an efficient way:
+    # as the transient vector supports the same API of vector, but performs
+    # updates in place, avoiding unnecessary object allocations.
+    #
+    # ```
+    # vec = Immutable::Vector(Int32).new
+    # v2 = vec.transient do |v|
+    #   100.times { |i| v = v.push(i) }
+    # end
+    # v2.size # => 100
+    # ```
+    #
+    # Note that, as the transient is mutable, it is not thread-safe.
     def transient
       t = Transient.new(@trie, @tail.dup)
       yield t

--- a/src/immutable/vector.cr
+++ b/src/immutable/vector.cr
@@ -31,7 +31,7 @@
 require "./vector/trie"
 
 module Immutable
-  struct Vector(T)
+  class Vector(T)
     include Enumerable(T)
     include Iterable
     include Comparable(Vector)

--- a/src/immutable/vector/trie.cr
+++ b/src/immutable/vector/trie.cr
@@ -1,6 +1,6 @@
 module Immutable
-  struct Vector(T)
-    struct Trie(T)
+  class Vector(T)
+    class Trie(T)
       BITS_PER_LEVEL = 5_u32
       BLOCK_SIZE = (2 ** BITS_PER_LEVEL).to_u32
       INDEX_MASK = BLOCK_SIZE - 1
@@ -184,6 +184,10 @@ module Immutable
       def inspect
         return @values.inspect if leaf?
         "[#{@children.map { |c| c.inspect }.join(", ")}]"
+      end
+
+      def clear_owner!
+        @owner = nil
       end
 
       def self.empty

--- a/src/immutable/vector/trie.cr
+++ b/src/immutable/vector/trie.cr
@@ -188,10 +188,11 @@ module Immutable
 
       def clear_owner!
         @owner = nil
+        self
       end
 
-      def self.empty
-        Trie.new([] of T)
+      def self.empty(from = nil : UInt64)
+        Trie.new([] of T, from)
       end
 
       def self.from(elems : Array(T))
@@ -200,6 +201,14 @@ module Immutable
           trie = trie.push_leaf(leaf)
         end
         trie
+      end
+
+      def self.from(elems : Array(T), from : UInt64)
+        trie = Trie(T).empty(from)
+        elems.each_slice(BLOCK_SIZE) do |leaf|
+          trie = trie.push_leaf!(leaf, from)
+        end
+        trie.clear_owner!
       end
 
       protected def set(index : Int, value : T) : Trie(T)

--- a/src/immutable/vector/trie.cr
+++ b/src/immutable/vector/trie.cr
@@ -13,13 +13,14 @@ module Immutable
       @values   : Array(T)
       @size     : Int32
       @levels   : Int32
+      @owner    : UInt64?
 
-      def initialize(@children : Array(Trie(T)), @levels : Int32)
+      def initialize(@children : Array(Trie(T)), @levels : Int32, @owner = nil : UInt64?)
         @size   = @children.reduce(0) { |size, child| size + child.size }
         @values = [] of T
       end
 
-      def initialize(@values : Array(T))
+      def initialize(@values : Array(T), @owner = nil : UInt64?)
         @size     = @values.size
         @levels   = 0
         @children = [] of Trie(T)
@@ -39,11 +40,24 @@ module Immutable
         set(index, value)
       end
 
+      def update!(index : Int, value : T, from : UInt64) : Trie(T)
+        raise IndexError.new if index < 0 || index >= size
+        set!(index, value, from)
+      end
+
       def push(value : T) : Trie(T)
         if full?
           Trie.new([self], @levels + 1).push(value)
         else
           set(@size, value)
+        end
+      end
+
+      def push!(value : T, from : UInt64) : Trie(T)
+        if full?
+          Trie.new([self], @levels + 1).push(value)
+        else
+          set!(@size, value, from)
         end
       end
 
@@ -56,6 +70,22 @@ module Immutable
           return Trie.new(@children[0...-1], @levels)
         end
         Trie.new(@children[0...-1].push(child), @levels)
+      end
+
+      def pop!(from : UInt64)
+        raise IndexError.new if size == 0
+        return pop unless from == @owner
+        if leaf?
+          @values.pop
+          return self
+        end
+        child = @children.last.pop!
+        if child.empty?
+          return @children.first if @children.size == 2
+          @children.pop
+        end
+        @children[-1] = child
+        self
       end
 
       def each
@@ -138,8 +168,19 @@ module Immutable
 
       protected def set(index : Int, value : T) : Trie(T)
         child_idx = child_index(index)
-        return Trie.new(update_values(@values, child_idx, value)) if leaf?
-        Trie.new(update_children(@children, child_idx, value, index), @levels)
+        return Trie.new(update_values(child_idx, value)) if leaf?
+        Trie.new(update_children(child_idx, value, index), @levels)
+      end
+
+      protected def set!(index : Int, value : T, from : UInt64) : Trie(T)
+        return set(index, value) unless from == @owner
+        child_idx = child_index(index)
+        if leaf?
+          update_values!(child_idx, value, from)
+        else
+          update_children!(child_idx, value, index, from)
+        end
+        self
       end
 
       protected def lookup(index : Int)
@@ -161,20 +202,33 @@ module Immutable
         (index >> (@levels * BITS_PER_LEVEL)) & INDEX_MASK
       end
 
-      private def update_children(children : Array(Trie(T)), index, value, idx) : Array(Trie(T))
+      private def update_children(index : Int, value : T, idx : Int) : Array(Trie(T))
         @children.dup.tap do |cs|
           cs << Trie(T).new([] of Trie(T), @levels - 1) if cs.size == index
           cs[index] = cs[index].set(idx, value)
         end
       end
 
-      private def update_values(values : Array(T), index : Int, value : T) : Array(T)
+      private def update_children!(index : Int, value : T, idx : Int, from : UInt64)
+        @children << Trie(T).new([] of Trie(T), @levels - 1, @owner) if @children.size == index
+        @children[index] = @children[index].set!(idx, value, from)
+      end
+
+      private def update_values(index : Int, value : T) : Array(T)
         @values.dup.tap do |vs|
           if vs.size == index
             vs << value
           else
             vs[index] = value
           end
+        end
+      end
+
+      private def update_values!(index : Int, value : T, from : UInt64)
+        if @values.size == index
+          @values << value
+        else
+          @values[index] = value
         end
       end
 


### PR DESCRIPTION
Implement transient structures to make bulk updates efficient. Transient structures are mutable and perform updates in-place. They can be converted from/into immutable structures in constant time, and they get invalidated after the updates are applied:

``` crystal
vector = Immutable::Vector.new([1, 2, 3])

vector = vector.transient do |vec|
  100.times { |i| vec = vec.push(i) }
end
```

Roadmap:
- [x] implement `Vector::Transient`
- [x] implement `Map::Transient`
